### PR TITLE
feat: implement QR code features and improve UI responsiveness (Resolves #5)

### DIFF
--- a/client/src/components/LocationGridView.vue
+++ b/client/src/components/LocationGridView.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted, computed } from 'vue';
 import api from '../api';
 
-const emit = defineEmits(['select']);
+const emit = defineEmits(['select', 'edit-location', 'edit-part']);
 
 const locations = ref([]);
 const loading = ref(true);
@@ -65,6 +65,16 @@ const confirmSelection = () => {
         closePreview();
     }
 };
+
+const handleEditLocation = (loc) => {
+    emit('edit-location', loc);
+    closePreview();
+};
+
+const handleEditPart = (part) => {
+    emit('edit-part', part);
+    closePreview();
+};
 </script>
 
 <template>
@@ -111,9 +121,12 @@ const confirmSelection = () => {
             </div>
             
             <div class="modal-body">
-                <div class="loc-summary">
+                <div class="loc-summary clickable-item" @click="handleEditLocation(previewLocation)" title="保管庫を編集">
                     <img v-if="previewLocation.image_path" :src="`${api.defaults.baseURL.replace('/api', '')}${previewLocation.image_path}`" class="preview-loc-img" />
-                    <p class="description">{{ previewLocation.description || '説明なし' }}</p>
+                    <div class="loc-info-text">
+                        <p class="description">{{ previewLocation.description || '説明なし' }}</p>
+                        <p v-if="previewLocation.qr_code" class="qr-code-badge">📱 {{ previewLocation.qr_code }}</p>
+                    </div>
                 </div>
 
                 <h3>保管されているパーツ ({{ previewParts.length }})</h3>
@@ -122,11 +135,12 @@ const confirmSelection = () => {
                     パーツは登録されていません
                 </div>
                 <div v-else class="preview-list">
-                    <div v-for="part in previewParts" :key="part.id" class="preview-item">
+                    <div v-for="part in previewParts" :key="part.id" class="preview-item clickable-item" @click="handleEditPart(part)" title="パーツを編集">
                         <img v-if="part.image_path" :src="part.image_path" class="part-thumb" />
                         <span v-else class="part-thumb-placeholder">⚡️</span>
                         <div class="part-details">
                             <span class="part-name">{{ part.name }}</span>
+                            <span v-if="part.qr_code" class="qr-code-badge" style="margin-top: 2px;">📱 {{ part.qr_code }}</span>
                             <span class="part-qty">{{ part.quantity }} pcs</span>
                         </div>
                     </div>
@@ -379,5 +393,32 @@ const confirmSelection = () => {
     display: flex;
     justify-content: flex-end;
     gap: 1rem;
+}
+
+.clickable-item {
+    cursor: pointer;
+    transition: background 0.2s;
+}
+.clickable-item:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+.qr-code-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.75rem;
+    font-family: monospace;
+    background: rgba(245, 158, 11, 0.15);
+    color: #fcd34d;
+    padding: 0.1rem 0.5rem;
+    border-radius: 4px;
+    border: 1px solid rgba(245, 158, 11, 0.3);
+    margin-top: 0.2rem;
+    width: fit-content;
+}
+.loc-info-text {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 }
 </style>

--- a/client/src/components/MasterDataManagement.vue
+++ b/client/src/components/MasterDataManagement.vue
@@ -4,6 +4,13 @@ import api from '../api';
 import draggable from 'vuedraggable';
 import MiniQrScanner from './MiniQrScanner.vue';
 
+const props = defineProps({
+    initialLocationEditId: {
+        type: [Number, String],
+        default: null
+    }
+});
+
 const emit = defineEmits(['close']);
 
 const categories = ref([]);
@@ -33,6 +40,14 @@ const fetchData = async () => {
     categories.value = catsRes.data;
     locations.value = locsRes.data;
     tags.value = tagsRes.data;
+
+    if (props.initialLocationEditId && !editingId.value) {
+        const loc = locations.value.find(l => l.id == props.initialLocationEditId);
+        if (loc) {
+            activeTab.value = 'locations';
+            startEdit('location', loc);
+        }
+    }
   } catch (err) {
     console.error('Failed to load data', err);
   }


### PR DESCRIPTION
# 実装完了報告

今回ご依頼いただいた「部品一覧画面のQR対応とUI改善」について、実装および確認が完了いたしました。
以下に変更内容をまとめます。

## 対応内容

### 1. トップ画面（部品一覧）のクイック編集とQRコードの表示
- パネルビューおよびリストビューのインライン編集に「QRコード」の入力枠を追加しました。
- 各編集欄の横にカメラアイコン `📷` を配置し、タップすることでその場でQRコードをスキャンして値を自動入力できるようにしました。
- 登録後（または登録済み）のパーツについて、パネルビューおよびリストビューの名前の下に、`🏷️ (QRコード値)` という形で控えめなサイズで表示するようにしました。

### 2. リスト絞り込み状態の維持
- これまでは詳細編集モーダル（`PartForm.vue`）を保存して閉じた際にリストデータ全体を再描画（Keyの更新）していましたが、内部データの再取得機能（`fetchParts()`）のみをコールするように変更しました。
- これにより、保管場所やカテゴリで絞り込んでいた一覧の状態が、編集後もそのまま維持されるようになりました。

### 3. スマホのリスト表示改善
- リストビューの表レイアウトにCSSのメディアクエリを導入しました。
- スマホなど横幅の狭い画面（`768px` 以下）で閲覧した際には、「カテゴリ」と「保管場所」の列を非表示にする `hide-on-mobile` クラスを付与し、1行あたりの表示をすっきり見やすく調整しました。

### 4. 保管庫ビューのポップアップメニュー強化
- 保管庫の一覧から個別の保管庫をクリックして開くポップアップメニューに対し、保管庫自体および各パーツをクリックできるようにスタイルとイベントを追加しました（ホバー時に少し明るくなり、カーソルがポインターに変わります）。
- ポップアップ内の保管庫情報パネル、および各パーツのリスト項目に、控えめなサイズで登録済みのQRコード値を表示するようにしました。
- **保管庫情報のクリック時**: 設定メニューの「マスタ管理」が即座に開き、該当の保管庫が最初から編集状態になるように連携を実装しました。
- **パーツ情報のクリック時**: トップ画面と同じパーツ詳細編集モーダル（`PartForm.vue`）が展開するようにイベントをつなぎ込みました。

## 今後のステップ
すべてのコード変更とビルド確認が完了し、`feature/issue-5` ブランチに変更が反映されています。
ローカルで動作をご確認いただき、問題がなければ `main` ブランチへのマージ等をお願いいたします。
