### PR TITLE
スマホ等で撮影した画像アップロード時に左に90度傾く不具合を修正

### DIFF
--- a/server/utils/image.js
+++ b/server/utils/image.js
@@ -3,14 +3,19 @@ const sharp = require('sharp');
 async function resizeImageBuffer(buffer, maxWidth = 1000) {
     try {
         const metadata = await sharp(buffer).metadata();
+        // スマホなどのカメラで撮影された画像のEXIF(Orientation)情報をもとに正しい向きに自動回転させる
+        const pipeline = sharp(buffer).rotate();
+
         if (metadata.width > maxWidth) {
-            const resized = await sharp(buffer)
+            const resized = await pipeline
                 .resize({ width: maxWidth, withoutEnlargement: true })
                 .toBuffer();
-            console.log(`Resized image buffer (${metadata.width}px -> ${maxWidth}px)`);
+            console.log(`Resized and auto-rotated image buffer (${metadata.width}px -> ${maxWidth}px)`);
             return resized;
         }
-        return buffer;
+
+        // リサイズ不要な場合でも回転だけは適用して返す
+        return await pipeline.toBuffer();
     } catch (err) {
         console.error('Failed to resize image:', err);
         return buffer;


### PR DESCRIPTION
Closes #17\n## 修正内容\n`sharp` ライブラリによるリサイズ処理で EXIF (Orientation) メタデータがデフォルトで削除されるため、スマホなどのカメラで撮影された画像が持つ回転情報が失われ、左に90度転がって表示される不具合がありました。\nリサイズ前に `sharp().rotate()` を実行し、EXIF の向きに従って自動回転させることで本来の向きのまま登録・表示されるように修正しました。